### PR TITLE
Fix Error component path

### DIFF
--- a/bindings/Next.re
+++ b/bindings/Next.re
@@ -100,7 +100,7 @@ module Head = {
 };
 
 module Error = {
-  [@bs.module "next/head"] [@react.component]
+  [@bs.module "next/error"] [@react.component]
   external make: (~statusCode: int, ~children: React.element) => React.element =
     "default";
 };


### PR DESCRIPTION
It would appear the path used for the Next.js `Error` component was
incorrect, based on the [documentation](https://github.com/Raimondi/delimitMate/issues/287).
